### PR TITLE
API compatibility, typos, more tests, and remove "unsafe"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,6 @@ rust:
 - stable
 - beta
 - nightly
-env:
-- TEST=true
-- TEST=false
-matrix:
-  exclude:
-  - rust: stable
-    env: TEST=true
-  - rust: beta
-    env: TEST=true
-  - rust: nightly
-    env: TEST=false
 script:
 - cargo build --verbose
-- if "$TEST"; then cargo test --verbose; fi
+- cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utf8-chars"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["warlock <internalmike@gmail.com>"]
 description = "Char-per-char iterator and `read_char` method for `BufRead`."
 readme = "README.md"
@@ -15,4 +15,4 @@ arrayvec = "0.5.0"
 
 [dev-dependencies]
 quickcheck = "0.9.0"
-quickcheck_macros = "0.8.0"
+quickcheck_macros = "0.9.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(test, feature(result_map_or_else))]
 #[cfg(test)]
 extern crate quickcheck;
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,12 @@ use std::error::{Error};
 use std::io::{self, BufRead};
 use arrayvec::{ArrayVec};
 
-/// A structure, containing readed bytes, and an [`io::Error`](std::io::Error).
-/// The `io::Error` is an actual I/O error if some occuried,
+/// A structure, containing read bytes, and an [`io::Error`](std::io::Error).
+/// The `io::Error` is an actual I/O error if some occurred,
 /// or a synthetic error with either the [`UnexpectedEof`](std::io::ErrorKind::UnexpectedEof)
 /// kind if a multi-byte char was unexpectedly terminated,
 /// either the [`InvalidData`](std::io::ErrorKind::InvalidData)
-/// kind if no actual I/O error occuried, but readed byte sequence was not recognised as a valid UTF-8.  
+/// kind if no actual I/O error occurred, but read byte sequence was not recognised as a valid UTF-8.  
 #[derive(Debug)]
 pub struct ReadCharError {
     bytes: ArrayVec<[u8; SEQUENCE_MAX_LENGTH as usize]>,
@@ -43,7 +43,7 @@ impl fmt::Display for ReadCharError {
         for b in self.as_bytes() {
             write!(f, " {:02X}", b)?;
         }
-        write!(f, " readed")?;
+        write!(f, " read")?;
         match self.as_io_error().kind() {
             io::ErrorKind::InvalidData => { },
             io::ErrorKind::UnexpectedEof => { write!(f, " (unexpected EOF)")?; }
@@ -110,9 +110,9 @@ pub trait BufReadCharsExt : BufRead {
     /// Reads a char from the underlying reader.
     ///
     /// Returns
-    /// - `Ok(Some(char))` if a char has succesfully readed,
-    /// - `Ok(None)` if the stream has reached EOF before any byte was readed,
-    /// - `Err(err)` if an I/O error occuried, or readed byte sequence was not recognised as a valid UTF-8.
+    /// - `Ok(Some(char))` if a char has successfully read,
+    /// - `Ok(None)` if the stream has reached EOF before any byte was read,
+    /// - `Err(err)` if an I/O error occurred, or read byte sequence was not recognised as a valid UTF-8.
     ///
     /// If this function encounters an error of the kind [`io::ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted)
     /// then the error is ignored and the operation will continue.


### PR DESCRIPTION
Hi!  I need exactly what this crate provides for a little side project, so I thought I make some drive-by contributions while I'm here.

My main motivation was removing `unsafe` and the new `io_chars()` method, because handling an `io::Error` feels better.  If you don't like this solution, maybe `ReadCharError` could be made into an `io::Error` in some way.

Let me know what you think, and have a nice day :)